### PR TITLE
Add details page title factory

### DIFF
--- a/addon/utils/details-page-title-factory.js
+++ b/addon/utils/details-page-title-factory.js
@@ -2,6 +2,13 @@ import Ember from 'ember'
 
 const {String: EmberString, get} = Ember
 
+/**
+ * factory for a details page title handler
+ * will get a dynamic title from a route's controller
+ * based on a path to the data in its model
+ * @param {string} modelPath - path in model to dynamic title data
+ * @returns {array} - array of title sections
+ */
 export default function pageTitleFactory (modelPath) {
   return function (sections, defaultTitle) {
     const name = get(this.controller.model, modelPath)

--- a/addon/utils/details-page-title-factory.js
+++ b/addon/utils/details-page-title-factory.js
@@ -1,0 +1,16 @@
+import Ember from 'ember'
+
+const {String: EmberString, get} = Ember
+
+export default function pageTitleFactory (modelPath) {
+  return function (sections, defaultTitle) {
+    const name = get(this.controller.model, modelPath)
+    let tab = get(this.controller, 'selectedTabId')
+
+    if (tab) {
+      tab = EmberString.capitalize(tab.replace(/-/g, ' '))
+    }
+
+    return [name, tab]
+  }
+}

--- a/app/utils/details-page-title-factory.js
+++ b/app/utils/details-page-title-factory.js
@@ -1,1 +1,1 @@
-export {default, initialize} from 'ember-frost-page-title/utils/details-page-title-factory'
+export {default} from 'ember-frost-page-title/utils/details-page-title-factory'

--- a/app/utils/details-page-title-factory.js
+++ b/app/utils/details-page-title-factory.js
@@ -1,0 +1,1 @@
+export {default, initialize} from 'ember-frost-page-title/utils/details-page-title-factory'

--- a/docs/frost-page-title.md
+++ b/docs/frost-page-title.md
@@ -62,7 +62,7 @@ The service provides a `defaultHandler` and an `updateTitle` method for updating
 The `defaultHandler` method takes a url (defaulted to `window.location.hash` or `window.location.pathname`, splits it on each `/`, discards anything that doesn't look like words, converting each `-` into a space and capitalizing each word. Example: `/myapp/#/foo-bar/baz` would become `['foo bar', 'baz']`, which the update method would convert to a page title of `Foo Bar | Baz`.
 
 ### #updateTitle()
-The `updateTitle` function runs runs the `defaultHandler` and the hanslers built up by routes using the mixin and joins them with either a "|" or whatever you set in your config for `APP['frost-page-title'].delimiter` (see example above).
+The `updateTitle` function runs runs the `defaultHandler` and the handlers built up by routes using the mixin and joins them with either a "|" or whatever you set in your config for `APP['frost-page-title'].delimiter` (see example above).
 
 ## Details page title factory util
 Provided with this addon is a util that handles the default behavior for our details pages. They typically get the title from a display attribute in the model, and append the name of the currently selected tab (automatically capitalized and de-deasherized). For example:

--- a/docs/frost-page-title.md
+++ b/docs/frost-page-title.md
@@ -64,6 +64,30 @@ The `defaultHandler` method takes a url (defaulted to `window.location.hash` or 
 ### #updateTitle()
 The `updateTitle` function runs runs the `defaultHandler` and the hanslers built up by routes using the mixin and joins them with either a "|" or whatever you set in your config for `APP['frost-page-title'].delimiter` (see example above).
 
+## Details page title factory util
+Provided with this addon is a util that handles the default behavior for our details pages. They typically get the title from a display attribute in the model, and append the name of the currently selected tab (automatically capitalized and de-deasherized). For example:
+
+```
+// some route
+
+import pageTitleFactory from 'ember-frost-page-title/utils/details-page-title-factory'
+...
+  pageTitleHandler: pageTitleFactory('displayData.displayTitle')
+...
+```
+
+So if your url is /somethings-details/selectedTabId=secret-details, and your data looks like this:
+
+```
+{
+  displayData: {
+    'Some thing'
+  }
+}
+```
+
+Your title will be `Some thing | Secret details`
+
 ## Examples
 
 ### Default

--- a/tests/unit/utils/details-page-title-factory-test.js
+++ b/tests/unit/utils/details-page-title-factory-test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 import pageTitleFactory from 'ember-frost-page-title/utils/details-page-title-factory'
-import {afterEach, beforeEach, describe, it} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
 describe('Unit / utils / details-page-title-factory /', function () {
   let dummyRoute

--- a/tests/unit/utils/details-page-title-factory-test.js
+++ b/tests/unit/utils/details-page-title-factory-test.js
@@ -1,0 +1,42 @@
+import {expect} from 'chai'
+import pageTitleFactory from 'ember-frost-page-title/utils/details-page-title-factory'
+import {afterEach, beforeEach, describe, it} from 'mocha'
+
+describe('Unit / utils / details-page-title-factory /', function () {
+  let dummyRoute
+
+  beforeEach(function () {
+    dummyRoute = {
+      pageTitleHandler: pageTitleFactory('name'),
+
+      controller: {
+        model: {
+          name: 'Details page title'
+        },
+
+        selectedTabId: 'some-tab'
+      }
+    }
+  })
+
+  it('should return a function', function () {
+    expect(typeof dummyRoute.pageTitleHandler).to.equal('function')
+  })
+
+  describe('the generated handler', function () {
+    it('should return an array', function () {
+      let handlerOutput = dummyRoute.pageTitleHandler([], 'defaultTitle')
+      expect(Array.isArray(handlerOutput)).to.equal(true)
+    })
+
+    it('should get the data from the model via the modelPath', function () {
+      let handlerOutput = dummyRoute.pageTitleHandler([], 'defaultTitle')
+      expect(handlerOutput[0]).to.equal('Details page title')
+    })
+
+    it('should get the tab name and properly capitalize/de-dasherize it', function () {
+      let handlerOutput = dummyRoute.pageTitleHandler([], 'defaultTitle')
+      expect(handlerOutput[1]).to.equal('Some tab')
+    })
+  })
+})


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
No PR should be opened without opening an issue first.  Any change needs to be discussed before proceeding.

## Summary
Provide a general summary of the issue addressed in the title above

## Issue Number(s)
Which issue(s) does this PR address?

Put `Closes #XXXX` below to auto-close the issue that this PR addresses:

* Closes #

## Screenshots or recordings
Please provide screenshots or recordings if this PR is modifying the visual UI or UX.

## Checklist
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have evaluated if the _README.md_ documentation needs to be updated
* [ ] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [ ] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
  * changes to demo app (_/tests/dummy/_)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
    * addition of new CSS selectors
    * addition of new `ember-hook` selectors
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome
    * any changes to CSS selector names
    * any removal of CSS selectors
    * any changes to `ember-hook` selectors
    * possibly changes to test helpers (depends on the changes made)
  * any changes to the **_dependencies_** entry in the _package.json_ file

# CHANGELOG

* Added factory for BP details page behavior that is shared across many apps.
